### PR TITLE
Deactivate the broken link embedded in Circular 1-2016

### DIFF
--- a/_circular/circular-1-2016.md
+++ b/_circular/circular-1-2016.md
@@ -50,7 +50,7 @@ The subject matter refers.
 3.3&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;RSs shall advise their client/s on the need and rationale to modernize the survey in the SVY21 datum instead of only in the Cassini system where land lot boundaries are concerned.<br>
 
  
-4.&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;LSB would also like to draw RSs’ attention to CS Directive on Cadastral Survey Practices for a similar requirement under cadastral survey in particular item 2.14 on the ‘Need for Coordinates Verification for Refinement Purposes’. For easy reference, please refer to the link via www.sla.gov.sg/Portals/0/SurveyServices/CS%20Directives/CS%20Directive%20V4.0.pdf
+4.&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;LSB would also like to draw RSs’ attention to CS Directive on Cadastral Survey Practices for a similar requirement under cadastral survey in particular item 2.14 on the ‘Need for Coordinates Verification for Refinement Purposes’. For easy reference, please refer to the link via sla.gov.sg/Portals/0/SurveyServices/CS%20Directives/CS%20Directive%20V4.0.pdf
 
 5.&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;RSs shall conduct themselves professionally at all times when dealing with their clients.<br>
 

--- a/_circular/circular-1-2016.md
+++ b/_circular/circular-1-2016.md
@@ -50,7 +50,7 @@ The subject matter refers.
 3.3&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;RSs shall advise their client/s on the need and rationale to modernize the survey in the SVY21 datum instead of only in the Cassini system where land lot boundaries are concerned.<br>
 
 {:start="4"} 
-4.&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;LSB would also like to draw RSs’ attention to CS Directive on Cadastral Survey Practices for a similar requirement under cadastral survey in particular item 2.14 on the ‘Need for Coordinates Verification for Refinement Purposes’. For easy reference, please refer to the link via [http://www.sla.gov.sg/Portals/0/SurveyServices/CS%20Directives/CS%20Directive%20V4.0.pdf](http://www.sla.gov.sg/Portals/0/SurveyServices/CS%20Directives/CS%20Directive%20V4.0.pdf)<br>
+4.&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;LSB would also like to draw RSs’ attention to CS Directive on Cadastral Survey Practices for a similar requirement under cadastral survey in particular item 2.14 on the ‘Need for Coordinates Verification for Refinement Purposes’. For easy reference, please refer to the link via [http://www.sla.gov.sg/Portals/0/SurveyServices/CS%20Directives/CS%20Directive%20V4.0.pdf]
 
 5.&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;RSs shall conduct themselves professionally at all times when dealing with their clients.<br>
 

--- a/_circular/circular-1-2016.md
+++ b/_circular/circular-1-2016.md
@@ -50,7 +50,7 @@ The subject matter refers.
 3.3&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;RSs shall advise their client/s on the need and rationale to modernize the survey in the SVY21 datum instead of only in the Cassini system where land lot boundaries are concerned.<br>
 
  
-4.&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;LSB would also like to draw RSs’ attention to CS Directive on Cadastral Survey Practices for a similar requirement under cadastral survey in particular item 2.14 on the ‘Need for Coordinates Verification for Refinement Purposes’. For easy reference, please refer to the link via sla.gov.sg/Portals/0/SurveyServices/CS%20Directives/CS%20Directive%20V4.0.pdf
+4.&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;LSB would also like to draw RSs’ attention to CS Directive on Cadastral Survey Practices for a similar requirement under cadastral survey in particular item 2.14 on the ‘Need for Coordinates Verification for Refinement Purposes’. For easy reference, please refer to the link via [sla.gov.sg/Portals/0/SurveyServices/CS%20Directives/CS%20Directive%20V4.0.pdf]
 
 5.&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;RSs shall conduct themselves professionally at all times when dealing with their clients.<br>
 

--- a/_circular/circular-1-2016.md
+++ b/_circular/circular-1-2016.md
@@ -50,7 +50,7 @@ The subject matter refers.
 3.3&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;RSs shall advise their client/s on the need and rationale to modernize the survey in the SVY21 datum instead of only in the Cassini system where land lot boundaries are concerned.<br>
 
  
-4.&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;LSB would also like to draw RSs’ attention to CS Directive on Cadastral Survey Practices for a similar requirement under cadastral survey in particular item 2.14 on the ‘Need for Coordinates Verification for Refinement Purposes’. For easy reference, please refer to the link via [sla.gov.sg/Portals/0/SurveyServices/CS%20Directives/CS%20Directive%20V4.0.pdf]
+4.&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;LSB would also like to draw RSs’ attention to CS Directive on Cadastral Survey Practices for a similar requirement under cadastral survey in particular item 2.14 on the ‘Need for Coordinates Verification for Refinement Purposes’. For easy reference, please refer to the link via [http://www.sla.gov.sg/Portals/0/SurveyServices/CS%20Directives/CS%20Directive%20V4.0.pdf]
 
 5.&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;RSs shall conduct themselves professionally at all times when dealing with their clients.<br>
 

--- a/_circular/circular-1-2016.md
+++ b/_circular/circular-1-2016.md
@@ -50,7 +50,7 @@ The subject matter refers.
 3.3&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;RSs shall advise their client/s on the need and rationale to modernize the survey in the SVY21 datum instead of only in the Cassini system where land lot boundaries are concerned.<br>
 
  
-4.&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;LSB would also like to draw RSs’ attention to CS Directive on Cadastral Survey Practices for a similar requirement under cadastral survey in particular item 2.14 on the ‘Need for Coordinates Verification for Refinement Purposes’. For easy reference, please refer to the link via http://www.sla.gov.sg/Portals/0/SurveyServices/CS%20Directives/CS%20Directive%20V4.0.pdf
+4.&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;LSB would also like to draw RSs’ attention to CS Directive on Cadastral Survey Practices for a similar requirement under cadastral survey in particular item 2.14 on the ‘Need for Coordinates Verification for Refinement Purposes’. For easy reference, please refer to the link via www.sla.gov.sg/Portals/0/SurveyServices/CS%20Directives/CS%20Directive%20V4.0.pdf
 
 5.&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;RSs shall conduct themselves professionally at all times when dealing with their clients.<br>
 

--- a/_circular/circular-1-2016.md
+++ b/_circular/circular-1-2016.md
@@ -38,7 +38,7 @@ Dear Sir / Madam,
 
 The subject matter refers.
 
-{:start="2"} 
+ 
 2.&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Lately, Land Surveyors Board (LSB) have received feedbacks and complaints on unprofessional work by Registered Surveyors (RS) especially in non-cadastral surveys e.g. topographical and engineering surveys. There were instances where the coordinates for the survey done in SVY21 datum were not verified on ground resulting in encroachments and disputes between private owners / agencies and RSs. While some cases can be rectified at a cost, they are counter-productive and go against the code of professional conduct expected of an RS.<br>
 
 3.&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;LSB would like to remind RSs on the need to verify the SVY21 coordinates of the land lot boundaries on the ground for refinement purposes prior to their adoption on site. In this regard, LSB would like to draw RSs’ attention to the following when undertaking a non-cadastral survey work:<br>
@@ -49,8 +49,8 @@ The subject matter refers.
 
 3.3&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;RSs shall advise their client/s on the need and rationale to modernize the survey in the SVY21 datum instead of only in the Cassini system where land lot boundaries are concerned.<br>
 
-{:start="4"} 
-4.&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;LSB would also like to draw RSs’ attention to CS Directive on Cadastral Survey Practices for a similar requirement under cadastral survey in particular item 2.14 on the ‘Need for Coordinates Verification for Refinement Purposes’. For easy reference, please refer to the link via [http://www.sla.gov.sg/Portals/0/SurveyServices/CS%20Directives/CS%20Directive%20V4.0.pdf]
+ 
+4.&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;LSB would also like to draw RSs’ attention to CS Directive on Cadastral Survey Practices for a similar requirement under cadastral survey in particular item 2.14 on the ‘Need for Coordinates Verification for Refinement Purposes’. For easy reference, please refer to the link via http://www.sla.gov.sg/Portals/0/SurveyServices/CS%20Directives/CS%20Directive%20V4.0.pdf
 
 5.&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;RSs shall conduct themselves professionally at all times when dealing with their clients.<br>
 


### PR DESCRIPTION
Took out the weblink of CS Directive v 4.0