### PR TITLE
Update of contact number of Han Boon Juan

### DIFF
--- a/_find-a-surveyor/List of Practising Registered Surveyors.md
+++ b/_find-a-surveyor/List of Practising Registered Surveyors.md
@@ -282,7 +282,7 @@ to engage in survey work in Singapore.</p>
 <br>Blk 9003 Tampines Street 93
 <br>#03-150
 <br>Singapore 528837
-<br>Tel: 62602778</p>
+<br>Tel: -</p>
 </td>
 </tr>
 <tr>


### PR DESCRIPTION
As confirmed by Mr Han in his email to us on 11 June 2025, his co. number is no longer in use. As such, to take out his contact number in website.